### PR TITLE
Updated Docblock Type hinting to match Magento 2.3.5-p1 standard

### DIFF
--- a/Api/MagentoVersionInterface.php
+++ b/Api/MagentoVersionInterface.php
@@ -17,7 +17,7 @@ interface MagentoVersionInterface
 {
     /**
      * @method getVersionData
-     * @return array
+     * @return mixed[]
      */
     public function getVersionData();
 }

--- a/Api/ModuleVersionInterface.php
+++ b/Api/ModuleVersionInterface.php
@@ -17,7 +17,7 @@ interface ModuleVersionInterface
 {
     /**
      * @method getVersionData
-     * @return array
+     * @return mixed[]
      */
     public function getVersionData();
 }

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -11,10 +11,10 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
     <extension_attributes for="Magento\Catalog\Api\Data\ProductInterface">
-        <attribute code="parent_ids" type="array" />
+        <attribute code="parent_ids" type="mixed[]" />
         <attribute code="quantity" type="float" />
         <attribute code="product_url" type="string" />
-        <attribute code="additional_urls" type="array" />
-        <attribute code="product_images" type="array" />
+        <attribute code="additional_urls" type="mixed[]" />
+        <attribute code="product_images" type="mixed[]" />
     </extension_attributes>
 </config>


### PR DESCRIPTION
When making an API request via the SOAP client Magento2 attempts to parse all docblocks to provide an automated Web API Documentation based on the docblocks

As of 2.3.5-p1 it does not accept `@return array` as a valid docblock and attempts to parse it as a Class using the ReflectionClass in Magento2

This causes a \LogicException to be thrown breaking the entire API

This can be tested using a simple get request @ /soap/?wsdl_list=1 (this causes a wsdl file to be downloaded if called via the browser, open it via a text editor and it will contain the error `class "array" does not exist` )