### PR TITLE
Deprecate DataFeedWatch Connector module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,28 @@
-This procedure applies to **Magento 2 and later** versions, and **Magento Enterprise**.
+# DataFeedWatch Connector
 
-### To add your **Magento 2** **shop**, follow the steps below:
+This module has been deprecated in favour of the newer version.
 
-1.  In DataFeedWatch, click **Add Shop**
-    1.  Enter a **name for your shop** (use any name you like)
-    2.  Select **Magento 2** from the list of Shopping Carts
-    3.  Enter your **shop's** **address**
-    4.  Select the **product types**, you'd like us to get
-    5.  Click **Next Tab**
-        
-        ![](https://files.helpdocs.io/g56vkvlw7l/articles/783v6ihcks/1610971290778/2021-01-18-12-59-20.png)
-        
-2.  In the **Installation** tab
-    
-    1.  Select **I am the Shop Owner**
-    
-    ![](https://files.helpdocs.io/g56vkvlw7l/articles/hynk2wajtj/1608644080402/2020-12-22-09-28-33.png)
-    
-    If you can't access your shop's admin panel yourself, choose the other option and **send the instructions to the person who can log in and install DataFeedWatch**.
-    
-    1.  Download and install our [DataFeedWatch Plugin](https://github.com/datafeedwatch/connector)
-    2.  Log in to your **Magento** **Shop's Admin Panel**
-    3.  Go to **Stores > Configuration**
-    
-    ![](https://files.helpdocs.io/g56vkvlw7l/articles/783v6ihcks/1573824841713/magento-2-new-1.png)
-    
-    1.  Scroll down and click **DataFeedWatch > General**
-    2.  Click **Open** next to the option **Go To My DataFeedWatch**
-    
-    ![](https://files.helpdocs.io/g56vkvlw7l/articles/783v6ihcks/1574235745146/magento-2-new-7-kopia.png)
-    
-3.  When back in DataFeedWatch, **Updates Schedule** tab:
-    1.  From the first drop-down, select your **timezone**
-    2.  Use **Add Another Update** button, to add more than one daily update times
-        
-        ![](https://files.helpdocs.io/g56vkvlw7l/articles/iyk8ghemko/1607686017829/2020-12-11-12-25-54.png)
-        
-        If you need downloads above your plan—you'll easily add them **after you add this shop**, in Shop Settings. (Feature **not available in Shop Plan**.)
-        
-4.  To continue to **Internal Fields** tab, click **Next Tab**
-    1.  For each field on the left, select a [main mapping type](https://help.datafeedwatch.com/category/2w82bkoeo6-main-mapping-types) from the first drop-down
-        
-        You can just check and **accept our suggestions** where available.
-        
-    2.  From the second dropdown, choose one of the attributes from your shop
-        
-        ![](https://files.helpdocs.io/g56vkvlw7l/articles/iyk8ghemko/1607686654514/2020-12-11-12-33-19.png)
-        
-        If you'd like to change and optimize your product attributes, try using also our [IF Conditions](https://help.datafeedwatch.com/category/gicg944qbc-condition-types) and [Edit Values options](https://help.datafeedwatch.com/category/ablungrxpa-edit-values-types).
-        
-5.  To create a shop, click **Finish**
+### Where to find the newer version of the module?
+
+The new version of the module is available here: https://packagist.org/packages/datafeedwatch/dfwconnector-magento2
+
+### How to migrate to a newer version?
+
+1. You fill first need to SSH into the machine that is running your Magento shop. 
+2. After login go to Magento home directory.
+3. Ensure that Composer is installed, by checking which version you have:
+    ```
+   composer --version
+    ```
+4. Inside the Magento Home uninstall the module
+   ```
+   composer remove datafeedwatch/connector
+   ```
+5. Finally clean up tasks:
+   ```
+   bin/magento setup:upgrade
+   bin/magento cache:clean
+   bin/magento setup:di:compile
+   ```
+6. Follow the guide to install the new version of the module available here: https://packagist.org/packages/datafeedwatch/dfwconnector-magento2  
+7. You access tokens won't change and there is no need to update anything id DataFeedWatch.

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ The new version of the module is available here: https://packagist.org/packages/
 
 ### How to migrate to a newer version?
 
-1. You fill first need to SSH into the machine that is running your Magento shop. 
-2. After login go to Magento home directory.
-3. Ensure that Composer is installed, by checking which version you have:
+1. First, log into the machine running your Magento shop via SSH. 
+2. Then, go to the Magento home directory.
+3. Ensure the Composer is installed. To verify it, check which version you have:
     ```
    composer --version
     ```
-4. Inside the Magento Home uninstall the module
+4. Uninstall the module:
    ```
    composer remove datafeedwatch/connector
    ```
-5. Finally clean up tasks:
+5. Finally, the clean up tasks:
    ```
    bin/magento setup:upgrade
    bin/magento cache:clean
    bin/magento setup:di:compile
    ```
-6. Follow the guide to install the new version of the module available here: https://packagist.org/packages/datafeedwatch/dfwconnector-magento2  
-7. You access tokens won't change and there is no need to update anything id DataFeedWatch.
+6. Once completed, follow the guidelines to install the new version of the module available here: https://packagist.org/packages/datafeedwatch/dfwconnector-magento2  
+7. Your access tokens won’t change. Therefore, you don’t need to update anything in DataFeedWatch.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "7.*||~8.1.0||~8.2.0"
     },
     "type": "magento2-module",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
The DataFeedWatch Connector module has been deprecated in favour of the newer version. The change updates the README.md file of the deprecated module with all required information to switch to the new version.

Ticket: WW-9077
Url: https://cartdotcom.atlassian.net/browse/WW-9077